### PR TITLE
Single token + alternative URL to download IdP metadata XMLs

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -8,6 +8,11 @@ realm = spid
 
 # official IdP list repository
 spidMetadataOfficialURL = https://registry.spid.gov.it/entities-idp?&output=json
+
+# retrieve metadata XMLs from alternative URL
+spidMetadataAlternativeURLEnabled = false
+spidMetadataAlternativeURLPrefix = https://yourdomain.com/entities-idp/
+
 # if you want to import a single IdP from official IdP list repository ie. idp_11
 singleIdp=
 

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,13 @@ createfolders:
 
 build:
 	docker-compose build
+
+download-metadatas:
+	rm -fr entities-idp || true
+	mkdir -p entities-idp
+	rm -f download.sh || true
+	echo "#!/bin/bash" > download.sh
+	echo "curl -s -o validator.xml https://validator.spid.gov.it/metadata.xml" >> download.sh
+	echo "curl -s -o demo.xml https://demo.spid.gov.it/validator/metadata.xml" >> download.sh
+	curl -s https://registry.spid.gov.it/entities-idp?&output=json | jq -r '.[] | ["curl","-s","-o", "entities-idp/",.file_name,.registry_link] | join(" ")' | sed 's/\?output=json//g' >> download.sh
+

--- a/createidps.js
+++ b/createidps.js
@@ -6,7 +6,8 @@ const {
     httpCallKeycloakImportConfig,
     httpCallKeycloakCreateIdP,
     httpCallKeycloakDeleteIdP,
-    httpCallKeycloakCreateAllMappers
+    httpCallKeycloakCreateAllMappers,
+    httpGrabKeycloaktokenOnce
 } = require('./src/http')
 
 
@@ -106,5 +107,9 @@ var createKeycloackSpidIdPsMappers$ = createSpidIdPsOnKeycloak$.pipe(mergeMap(id
     }))
 }))
 
-
-createKeycloackSpidIdPsMappers$.subscribe(console.log)
+// retrieve a single keycloak token before starting
+httpGrabKeycloaktokenOnce().then(token => {
+    console.log('Successfully retrieved Keycloak token');
+    config.token = token;
+    createKeycloackSpidIdPsMappers$.subscribe(console.log);
+});

--- a/createidps.js
+++ b/createidps.js
@@ -40,7 +40,8 @@ if (config.createSpidValidatorIdP === 'true') {
         code: config.spidValidatorIdPAlias,
         organization_name: config.spidValidatorIdPAlias,
         organization_display_name: config.spidValidatorIdPDisplayName,
-        registry_link: config.spidValidatorIdPMetadataURL
+        registry_link: config.spidValidatorIdPMetadataURL,
+        file_name: 'validator.xml'
     }
     getOfficialSpididPsMetadata$ = concat(getOfficialSpididPsMetadata$, of(enrichIdpWithConfigData(spidValidatorIdPOfficialMetadata)))
 }
@@ -50,7 +51,8 @@ if (config.createSpidDemoIdP === 'true') {
         code: config.spidDemoIdPAlias,
         organization_name: config.spidDemoIdPAlias,
         organization_display_name: config.spidDemoIdPAlias,
-        registry_link: config.spidDemoIdPMetadataURL
+        registry_link: config.spidDemoIdPMetadataURL,
+        file_name: 'demo.xml'
     }
     getOfficialSpididPsMetadata$ = concat(getOfficialSpididPsMetadata$, of(enrichIdpWithConfigData(spidDemoIdPOfficialMetadata)))
 }
@@ -91,7 +93,7 @@ var enrichedModels$ = getKeycloakImportConfigModels$
         }
         let merged = {...idPTemplate, ...firstLevel}
         merged.config = configIdp
-        merged.config.metadataDescriptorUrl=idPOfficialMetadata.metadata_url;
+        merged.config.metadataDescriptorUrl=idPOfficialMetadata.registry_link;
         return merged
     }))
 

--- a/src/common.js
+++ b/src/common.js
@@ -40,8 +40,12 @@ exports.enrichIdpWithConfigData = function (idpOriginal) {
         ipa_entity_code: idpOriginal.code,
         entity_name: idpOriginal.organization_name,
         displayName: idpOriginal.organization_display_name,
+        registry_link: idpOriginal.registry_link.replace('?output=json', ''),
         metadata_url: idpOriginal.registry_link.replace('?output=json', '')
     };
+    if (config.spidMetadataAlternativeURLEnabled) {
+        idp['metadata_url']=config.spidMetadataAlternativeURLPrefix + idpOriginal.file_name;
+    }
     let cleanedupSpidName = idp.entity_name.replace('TI Trust Technologies', 'Tim').replace(/ ID|SPIDItalia | S\.C\.p\.A\.| S\.p\.A\.| srl| spa| italiane|PEC/ig, '');
     idp.alias = slugify(SPID_ALIAS_PREFIX + cleanedupSpidName).toLowerCase();
     if (idp.metadata_url != config.spidValidatorIdPMetadataURL) { // do not tamper official name as per AgID guidelines
@@ -55,7 +59,8 @@ exports.enrichIdpWithConfigData = function (idpOriginal) {
         organizationDisplayNames: config.organizationDisplayNames,
         organizationUrls: config.organizationUrls,
         attributeConsumingServiceName: config.attributeConsumingServiceName,
-        metadataDescriptorUrl: idp.metadata_url
+        metadataDescriptorUrl: idp.metadata_url,
+        useMetadataDescriptorUrl: true
     };
     return idp;
 }

--- a/src/http.js
+++ b/src/http.js
@@ -54,7 +54,15 @@ exports.httpGrabIdPsMetadata = function () {
 
 }
 
-const httpGrabKeycloaktoken = function () {
+const httpGrabKeycloaktoken = function() {
+    return new Promise(function(resolve) {
+        resolve(config.token)
+      });
+}
+
+exports.httpGrabKeycloaktoken = httpGrabKeycloaktoken
+
+const httpGrabKeycloaktokenOnce = function () {
     return axios(tokenConfig)
         .then(response => response.data.access_token)
         .catch(function (error) {
@@ -63,7 +71,7 @@ const httpGrabKeycloaktoken = function () {
         });
 }
 
-exports.httpGrabKeycloaktoken = httpGrabKeycloaktoken
+exports.httpGrabKeycloaktokenOnce = httpGrabKeycloaktokenOnce
 
 exports.httpCallKeycloakImportConfig = function (idPsMetadataUrl) {
     return httpGrabKeycloaktoken().then(token => {
@@ -80,8 +88,7 @@ exports.httpCallKeycloakImportConfig = function (idPsMetadataUrl) {
         };
         return axios(axiosConfig)
             .catch(function (error) {
-                //console.error(error);
-                console.error('Error importing IdP configuration from metadata '+idPsMetadataUrl);
+                console.error('Error importing IdP configuration from metadata - error ' + error.response.status + ' - ' + idPsMetadataUrl);
                 handleHttpError(error);
             });
     })
@@ -179,10 +186,10 @@ exports.httpCallKeycloakCreateAllMappers = function (idPAlias) {
         httpCallKeycloakCreateMapper(idPAlias, countyOfBirthMapperTemplate),
         httpCallKeycloakCreateMapper(idPAlias, mobilePhoneMapperTemplate),
         httpCallKeycloakCreateMapper(idPAlias, addressMapperTemplate),
-        httpCallKeycloakCreateMapper(idPAlias, digitalAddressMapperTemplate),
-        httpCallKeycloakCreateMapper(idPAlias, companyNameMapperTemplate),
-        httpCallKeycloakCreateMapper(idPAlias, companyAddressMapperTemplate),
-        httpCallKeycloakCreateMapper(idPAlias, vatNumberapperTemplate),
+        httpCallKeycloakCreateMapper(idPAlias, digitalAddressMapperTemplate)
+        // httpCallKeycloakCreateMapper(idPAlias, companyNameMapperTemplate),
+        // httpCallKeycloakCreateMapper(idPAlias, companyAddressMapperTemplate),
+        // httpCallKeycloakCreateMapper(idPAlias, vatNumberapperTemplate),
     ])
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for downloading IdP metadata XMLs from an alternative URL and improve Keycloak token handling.
> 
>   - **Environment Variables**:
>     - Add `spidMetadataAlternativeURLEnabled` and `spidMetadataAlternativeURLPrefix` to `.env-example` for alternative metadata URL.
>   - **Makefile**:
>     - Add `download-metadatas` target to download IdP metadata XMLs, creating `download.sh` script.
>   - **Metadata Handling**:
>     - Update `enrichIdpWithConfigData` in `src/common.js` to use alternative URL if enabled.
>     - Modify `createidps.js` to include `file_name` in IdP metadata objects.
>   - **Keycloak Token Handling**:
>     - Add `httpGrabKeycloaktokenOnce` in `src/http.js` to retrieve a single Keycloak token before operations.
>     - Update `createidps.js` to use `httpGrabKeycloaktokenOnce` before creating IdPs.
>   - **Miscellaneous**:
>     - Comment out some mappers in `httpCallKeycloakCreateAllMappers` in `src/http.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nicolabeghin%2Fkeycloak-spid-provider-configuration-client&utm_source=github&utm_medium=referral)<sup> for bc6a7148df2f862a120cfc100382cd3c35550d69. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->