### PR TITLE
Support for spid-saml-check demo + spid-sp-test

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -37,7 +37,7 @@ createSpidTestDemoIdP = false
 spidTestDemoIdPAlias = spid-saml-check-demo
 spidTestDemoIdpMetadataURL = https://localhost:8443/demo/metadata.xml
 
-# local spid-saml-check demo validator
+# spid-sp-test
 createSpidSpTestIdP = false
 spidSpTestIdPAlias = spid-sp-test
 spidSpTestIdPMetadataURL = https://localhost:8443/spid-sp-test.xml

--- a/.env-example
+++ b/.env-example
@@ -27,10 +27,20 @@ spidValidatorIdPAlias = Validator
 spidValidatorIdPDisplayName = SPID Validator
 spidValidatorIdPMetadataURL = https://validator.spid.gov.it/metadata.xml
 
-# local spid 
+# local spid-saml-check 
 createSpidTestIdP = false
-spidTestIdPAlias = spid-testenv2
-spidTestIdPMetadataURL = http://localhost:8088/metadata
+spidTestIdPAlias = spid-saml-check
+spidTestIdPMetadataURL = https://localhost:8443/metadata.xml
+
+# local spid-saml-check demo validator
+createSpidTestDemoIdP = false
+spidTestDemoIdPAlias = spid-saml-check-demo
+spidTestDemoIdpMetadataURL = https://localhost:8443/demo/metadata.xml
+
+# local spid-saml-check demo validator
+createSpidSpTestIdP = false
+spidSpTestIdPAlias = spid-sp-test
+spidSpTestIdPMetadataURL = https://localhost:8443/spid-sp-test.xml
 
 # additional metadata info as per Avviso SPID №29 versione 3
 organizationDisplayNames = en|Organization name,it|Organization name

--- a/.env-example
+++ b/.env-example
@@ -35,7 +35,7 @@ spidTestIdPMetadataURL = https://localhost:8443/metadata.xml
 # local spid-saml-check demo validator
 createSpidTestDemoIdP = false
 spidTestDemoIdPAlias = spid-saml-check-demo
-spidTestDemoIdpMetadataURL = https://localhost:8443/demo/metadata.xml
+spidTestDemoIdPMetadataURL = https://localhost:8443/demo/metadata.xml
 
 # spid-sp-test
 createSpidSpTestIdP = false

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,6 @@
 name: Docker Image CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,11 @@
+name: Docker Image CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker compose build

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,5 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Setup configuration
+      run: cp .env-example .env
     - name: Build the Docker image
       run: docker compose build
+

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ activemq-data
 #########
 .env
 *.log
+
+download.sh
+spid-sp-test.xml

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,5 @@ download-metadatas:
 	echo "curl -s -o validator.xml https://validator.spid.gov.it/metadata.xml" >> download.sh
 	echo "curl -s -o demo.xml https://demo.spid.gov.it/validator/metadata.xml" >> download.sh
 	curl -s https://registry.spid.gov.it/entities-idp?&output=json | jq -r '.[] | ["curl","-s","-o", "entities-idp/",.file_name,.registry_link] | join(" ")' | sed 's/\?output=json//g' >> download.sh
+	chmod +x download.sh
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ spidTestIdPAlias = spid-saml-check
 spidTestIdPMetadataURL = https://localhost:8443/metadata.xml
 ```
 
+If you have a local [spid-saml-check](https://github.com/italia/spid-saml-check) demo instance, set the following `.env` file properties
+
+```
+createSpidTestDemoIdP = true
+spidTestDemoIdpMetadataURL = https://localhost:8443/demo/metadata.xml
+```
+
+In both cases, make sure that Keycloak can reach the `spidTestIdPMetadataURL` and `spidTestDemoIdPMetadataURL` URLs and [trusts the `spid-saml-check` certificate](https://www.keycloak.org/server/keycloak-truststore#_configuring_the_system_truststore) (found in `spid-saml-check/spid-validator/config/spid-saml-check.crt`). You can create a new certificate based on your domain (if different from `localhost:8443`) with the following command:
+
+    openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
+        -keyout spid-saml-check/spid-validator/config/spid-saml-check.key \
+        -out spid-saml-check/spid-validator/config/spid-saml-check.pem \
+        -subj "/C=IT/ST=MI/L=Milan/O=AgID/OU=Servizio Accreditamento/CN=yourdomain.com:8443" \
+        -addext "subjectAltName = DNS:yourdomain.com, DNS:localhost:8443"
+
+If you want to use [spid-sp-test](https://github.com/italia/spid-sp-test), set the following `.env` file properties
+
+```
+createSpidSpTestIdP = true
+spidSpTestIdPMetadataURL = http://localhost/spid-sp-test.xml
+```
+
+Make sure you can uploaded the spid-sp-test metadata.xml to a Keycloak-reachable URL as above. The XML file can be generated with 
+
+    docker run --rm -it italia/spid-sp-test --idp-metadata > spid-sp-test.xml
+
+
 ## Running the tool
 ### Docker
 Easiest way by leveraging Docker:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you have a local [spid-saml-check](https://github.com/italia/spid-saml-check)
 
 ```
 createSpidTestDemoIdP = true
-spidTestDemoIdpMetadataURL = https://localhost:8443/demo/metadata.xml
+spidTestDemoIdPMetadataURL = https://localhost:8443/demo/metadata.xml
 ```
 
 In both cases, make sure that Keycloak can reach the `spidTestIdPMetadataURL` and `spidTestDemoIdPMetadataURL` URLs and [trusts the `spid-saml-check` certificate](https://www.keycloak.org/server/keycloak-truststore#_configuring_the_system_truststore) (found in `spid-saml-check/spid-validator/config/spid-saml-check.crt`). You can create a new certificate based on your domain (if different from `localhost:8443`) with the following command:

--- a/createidps.js
+++ b/createidps.js
@@ -30,7 +30,8 @@ if (config.createSpidTestIdP === 'true') {
         code: config.spidTestIdPAlias,
         organization_name: config.spidTestIdPAlias,
         organization_display_name: config.spidTestIdPAlias,
-        registry_link: config.spidTestIdPMetadataURL
+        registry_link: config.spidTestIdPMetadataURL,
+        file_name: 'spid-saml-check.xml'
     }
     getOfficialSpididPsMetadata$ = concat(getOfficialSpididPsMetadata$, of(enrichIdpWithConfigData(spidTestIdPOfficialMetadata)));    
 }
@@ -57,16 +58,34 @@ if (config.createSpidDemoIdP === 'true') {
     getOfficialSpididPsMetadata$ = concat(getOfficialSpididPsMetadata$, of(enrichIdpWithConfigData(spidDemoIdPOfficialMetadata)))
 }
 
-
-var noIdpToSetUp; 
-getOfficialSpididPsMetadata$.pipe(isEmpty()).subscribe(r => {
-    noIdpToSetUp = r;
-});
-
-if(noIdpToSetUp){
-    console.error("No idp configured to be set up, exiting");
-    return;
+if (config.createSpidTestDemoIdP === 'true') {
+    let spidTestLocalDemoMetadata = {
+        code: config.spidTestDemoIdPAlias,
+        organization_name: config.spidTestDemoIdPAlias,
+        organization_display_name: config.spidTestDemoIdPAlias,
+        registry_link: config.spidTestDemoIdpMetadataURL,
+        file_name: 'spid-saml-check-demo.xml'
+    }
+    getOfficialSpididPsMetadata$ = concat(getOfficialSpididPsMetadata$, of(enrichIdpWithConfigData(spidTestLocalDemoMetadata)));       
 }
+
+if (config.createSpidSpTestIdP === 'true') {
+    let spidSpTestMetadata = {
+        code: config.spidSpTestIdPAlias,
+        organization_name: config.spidSpTestIdPAlias,
+        organization_display_name: config.spidSpTestIdPAlias,
+        registry_link: config.spidSpTestIdPMetadataURL,
+        file_name: 'spid-sp-test.xml'
+    }
+    getOfficialSpididPsMetadata$ = concat(getOfficialSpididPsMetadata$, of(enrichIdpWithConfigData(spidSpTestMetadata)));       
+}
+
+getOfficialSpididPsMetadata$.pipe(isEmpty()).subscribe(noIdpToSetUp => {
+    if (noIdpToSetUp) {
+        console.error("No idp configured to be set up, exiting");
+        process.exit(1);
+    }
+});
 
 //getOfficialSpididPsMetadata$.subscribe(console.log);
 

--- a/createidps.js
+++ b/createidps.js
@@ -63,7 +63,7 @@ if (config.createSpidTestDemoIdP === 'true') {
         code: config.spidTestDemoIdPAlias,
         organization_name: config.spidTestDemoIdPAlias,
         organization_display_name: config.spidTestDemoIdPAlias,
-        registry_link: config.spidTestDemoIdpMetadataURL,
+        registry_link: config.spidTestDemoIdPMetadataURL,
         file_name: 'spid-saml-check-demo.xml'
     }
     getOfficialSpididPsMetadata$ = concat(getOfficialSpididPsMetadata$, of(enrichIdpWithConfigData(spidTestLocalDemoMetadata)));       

--- a/src/common.js
+++ b/src/common.js
@@ -43,7 +43,7 @@ exports.enrichIdpWithConfigData = function (idpOriginal) {
         registry_link: idpOriginal.registry_link.replace('?output=json', ''),
         metadata_url: idpOriginal.registry_link.replace('?output=json', '')
     };
-    if (config.spidMetadataAlternativeURLEnabled) {
+    if (config.spidMetadataAlternativeURLEnabled === 'true' && idpOriginal.file_name) {
         idp['metadata_url']=config.spidMetadataAlternativeURLPrefix + idpOriginal.file_name;
     }
     let cleanedupSpidName = idp.entity_name.replace('TI Trust Technologies', 'Tim').replace(/ ID|SPIDItalia | S\.C\.p\.A\.| S\.p\.A\.| srl| spa| italiane|PEC/ig, '');

--- a/src/http.js
+++ b/src/http.js
@@ -88,7 +88,7 @@ exports.httpCallKeycloakImportConfig = function (idPsMetadataUrl) {
         };
         return axios(axiosConfig)
             .catch(function (error) {
-                console.error('Error importing IdP configuration from metadata - error ' + error.response.status + ' - ' + idPsMetadataUrl);
+                console.error('Error importing IdP configuration from metadata - error code ' + (error.response ? error.response.status : 'unknown') + ' - ' + idPsMetadataUrl);
                 handleHttpError(error);
             });
     })


### PR DESCRIPTION
Add support for `spid-saml-check demo` and `spid-sp-test`, and introduce Docker Image CI workflow.

  - **Configuration**:
    - Add support for `spid-saml-check demo` and `spid-sp-test` in `.env-example` and `createidps.js`.
    - Update `README.md` with instructions for configuring `spid-saml-check demo` and `spid-sp-test`.
  - **CI/CD**:
    - Add `docker-image.yml` for Docker Image CI on push and pull request.
  - **Scripts**:
    - Update `Makefile` to make `download.sh` executable.
    - Modify `createidps.js` to handle new IdPs `spid-saml-check demo` and `spid-sp-test`.
  - **Error Handling**:
    - Improve error logging in `http.js` for unknown error codes.